### PR TITLE
Add a general way to support any XML that Phoebus supports

### DIFF
--- a/phoebusgen/screen/screen.py
+++ b/phoebusgen/screen/screen.py
@@ -36,15 +36,23 @@ class Screen(object):
         :return: True is successful write, False otherwise
         """
         rough_string = tostring(self.root, 'utf-8')
-        reparse_xml = minidom.parseString(rough_string)
+        # Restore CDATA brakets, &lt; (-LESS-) -> < , &gt; (-GREATER-) -> >
+        s = rough_string.decode('utf-8').replace('-LBRCT-', '<')\
+                .replace('-RBRCT-', '>')\
+                .replace('-GREATER-', '>')\
+                .replace('-LESS-', '<')
+
         if file_name is None:
             file_name = self.bob_file
         if file_name is None:
             print('Output Phoebus file name is not set! First set bob_file or use file_name parameter')
             return False
         else:
+            # Note: the output xml file is super compact, not reader-friendly, but could use
+            # other tools to reformat it.
             with open(file_name, 'w') as f:
-                reparse_xml.writexml(f, indent="  ", addindent="  ", newl="\n", encoding="UTF-8")
+                f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+                f.write(s)
             return True
 
     def find_widget(self, widget_tag_name: str) -> Element:

--- a/phoebusgen/widget/widget.py
+++ b/phoebusgen/widget/widget.py
@@ -1,4 +1,4 @@
-from xml.etree.ElementTree import Element, SubElement, tostring
+from xml.etree.ElementTree import Element, SubElement, tostring, fromstring
 from xml.dom import minidom
 from phoebusgen._shared_property_helpers import _SharedPropertyFunctions
 
@@ -136,6 +136,26 @@ class _Widget(object):
         element = self.find_element(tag)
         if element is not None:
             self.root.remove(element)
+
+    def add_element(self, xmlstring: str, simplify=False) -> None:
+        """Add a string (XML node) into the root, xmlstring could be an arbitrary string that may
+        not be ready supported by other straightforwad APIs, e.g. rules. It is the user's
+        responsibility to prepare the right formatted xmlstring input.
+        """
+        try:
+            if simplify:
+                elem = fromstring(''.join(i.strip() for i in xmlstring.split("\n")))
+            else:
+                elem = fromstring(xmlstring.strip())
+        except:
+            print("Failed to read an Element object from the input string.")
+        else:
+            # if contains ![CDATA?, <scripts>
+            if '![CDATA' in xmlstring:
+                script_node = elem.find(".//text")
+                text = script_node.text.replace('>', '-GREATER-').replace('<', '-LESS-')
+                script_node.text = f"-LBRCT-![CDATA[{text}]]-RBRCT-"
+            self.root.append(elem)
 
     def get_element_value(self, tag: str) -> str:
         """


### PR DESCRIPTION
Implemented a quick and dirty way that allows adding any XML node into the XML tree root, the final generated .bob file is not formatted but could be reformatted by using other tools.

The idea is to add a node directly from a valid XML string, I used this way to handle the rules/scripts configuration, and found it should be able to cover all the cases. In order to correctly handle the script configuration, I did some tricky parts in the screen module, where ``CDATA`` text block is specially treated, that's where by default the XML strings are not well formatted.