### PR TITLE
Add hex value option to color methods

### DIFF
--- a/phoebusgen/widget/properties.py
+++ b/phoebusgen/widget/properties.py
@@ -237,17 +237,44 @@ class _ForegroundColor(object):
         e = self._shared.create_element(self.root, 'foreground_color')
         self._shared.create_color_element(e, name, None, None, None, None)
 
-    def foreground_color(self, red: int, green: int, blue: int, alpha: int = 255) -> None:
+    def foreground_color(self, *args) -> None:
         """
-        Add foreground color property to widget with RGB values
+        Add foreground color property to widget with RGB values or HEX value
 
         :param red: 0-255
         :param green: 0-255
         :param blue: 0-255
         :param alpha: 0-255. Default is 255
+
+        or
+
+        :param hex: #000000-#FFFFFF
+        :param alpha: 0-255. Default is 255
         """
         e = self._shared.create_element(self.root, 'foreground_color')
-        self._shared.create_color_element(e, None, red, green, blue, alpha)
+        alpha = 255
+        if len(args) == 4 and isinstance(args[0], int) and isinstance(args[1], int) and isinstance(args[2], int) and isinstance(args[3], int):
+            red = args[0]
+            green = args[1]
+            blue = args[2]
+            alpha = args[3]
+            self._shared.create_color_element(e, None, red, green, blue, alpha)
+        elif len(args) == 3 and isinstance(args[0], int) and isinstance(args[1], int) and isinstance(args[2], int):
+            red = args[0]
+            green = args[1]
+            blue = args[2]
+            self._shared.create_color_element(e, None, red, green, blue, alpha)
+        elif len(args) == 2 and isinstance(args[0], str) and isinstance(args[1], int):
+            hex = args[0].lstrip('#')
+            alpha = args[1]
+            rgb = tuple(int(hex[i:i+2], 16) for i in (0, 2, 4))
+            self._shared.create_color_element(e, None, rgb[0], rgb[1], rgb[2], alpha)
+        elif len(args) == 1 and isinstance(args[0], str):
+            hex = args[0].lstrip('#')
+            rgb = tuple(int(hex[i:i+2], 16) for i in (0, 2, 4))
+            self._shared.create_color_element(e, None, rgb[0], rgb[1], rgb[2], alpha)
+        else:
+            raise TypeError('Parameters should be (red: int, green: int, blue: int, alpha: int) or (hex: str, alpha: int)')
 
 class _BackgroundColor(object):
     def predefined_background_color(self, name: object) -> None:
@@ -258,17 +285,44 @@ class _BackgroundColor(object):
         e = self._shared.create_element(self.root, 'background_color')
         self._shared.create_color_element(e, name, None, None, None, None)
 
-    def background_color(self, red: int, green: int, blue: int, alpha: int = 255) -> None:
+    def background_color(self, *args) -> None:
         """
-        Add background color property to widget with RGB values
+        Add background color property to widget with RGB values or HEX value
 
         :param red: 0-255
         :param green: 0-255
         :param blue: 0-255
         :param alpha: 0-255. Default is 255
+
+        or
+
+        :param hex: #000000-#FFFFFF
+        :param alpha: 0-255. Default is 255
         """
         e = self._shared.create_element(self.root, 'background_color')
-        self._shared.create_color_element(e, None, red, green, blue, alpha)
+        alpha = 255
+        if len(args) == 4 and isinstance(args[0], int) and isinstance(args[1], int) and isinstance(args[2], int) and isinstance(args[3], int):
+            red = args[0]
+            green = args[1]
+            blue = args[2]
+            alpha = args[3]
+            self._shared.create_color_element(e, None, red, green, blue, alpha)
+        elif len(args) == 3 and isinstance(args[0], int) and isinstance(args[1], int) and isinstance(args[2], int):
+            red = args[0]
+            green = args[1]
+            blue = args[2]
+            self._shared.create_color_element(e, None, red, green, blue, alpha)
+        elif len(args) == 2 and isinstance(args[0], str) and isinstance(args[1], int):
+            hex = args[0].lstrip('#')
+            alpha = args[1]
+            rgb = tuple(int(hex[i:i+2], 16) for i in (0, 2, 4))
+            self._shared.create_color_element(e, None, rgb[0], rgb[1], rgb[2], alpha)
+        elif len(args) == 1 and isinstance(args[0], str):
+            hex = args[0].lstrip('#')
+            rgb = tuple(int(hex[i:i+2], 16) for i in (0, 2, 4))
+            self._shared.create_color_element(e, None, rgb[0], rgb[1], rgb[2], alpha)
+        else:
+            raise TypeError('Parameters should be (red: int, green: int, blue: int, alpha: int) or (hex: str, alpha: int)')
 
 class _Transparent(object):
     def transparent(self, transparent: bool = False) -> None:
@@ -758,7 +812,7 @@ class _Actions(object):
     # target should be an enum
     def action_open_display(self, file: str, target: str, description: str = None, macros: dict = None) -> None:
         """
-        Add open display action to widget. description and macros are optional params
+        Add open display action to widget. description and macros are optional args
 
         :param file: File name to open
         :param target: <specific strings only> tab, replace, window

--- a/tests/property_helpers.py
+++ b/tests/property_helpers.py
@@ -409,11 +409,33 @@ class TestForegroundColor(GenericTest):
         self.child_element_test(tag_name, 'color', None, {'name': 'Background', 'red': '255', 'green': '255',
                                                           'blue': '255', 'alpha': '255'})
 
-    def test_foreground_color(self):
+    def test_foreground_color_rgb(self):
         tag_name = 'foreground_color'
         self.element.foreground_color(5, 10, 15)
         self.child_element_test(tag_name, 'color', None, {'red': '5', 'green': '10',
                                                           'blue': '15', 'alpha': '255'})
+        
+    def test_foreground_color_rgb_alpha(self):
+        tag_name = 'foreground_color'
+        self.element.foreground_color(5, 10, 15, 100)
+        self.child_element_test(tag_name, 'color', None, {'red': '5', 'green': '10',
+                                                          'blue': '15', 'alpha': '100'})
+        
+    def test_foreground_color_hex(self):
+        tag_name = 'foreground_color'
+        self.element.foreground_color('#ffffc3')
+        self.child_element_test(tag_name, 'color', None, {'red': '255', 'green': '255',
+                                                          'blue': '195', 'alpha': '255'})
+        
+    def test_foreground_color_hex_alpha(self):
+        tag_name = 'foreground_color'
+        self.element.foreground_color('#ffffc3', 100)
+        self.child_element_test(tag_name, 'color', None, {'red': '255', 'green': '255',
+                                                          'blue': '195', 'alpha': '100'})
+        
+    def test_foreground_color_bad_args(self):
+        tag_name = 'foreground_color'
+        self.assertRaises(TypeError, self.element.foreground_color, 5, 10, 15, '#ffffff')
 
 
 class TestBackgroundColor(GenericTest):
@@ -422,10 +444,31 @@ class TestBackgroundColor(GenericTest):
         self.element.predefined_background_color(self.colors.MINOR)
         self.child_element_test(tag_name, 'color', None, {'name': 'MINOR', 'red': '255', 'green': '128', 'blue': '0', 'alpha': '255'})
 
-    def test_background_color(self):
+    def test_background_color_rgb(self):
         tag_name = 'background_color'
         self.element.background_color(5, 10, 15)
         self.child_element_test(tag_name, 'color', None, {'red': '5', 'green': '10', 'blue': '15', 'alpha': '255'})
+        
+    def test_background_color_rgb_alpha(self):
+        tag_name = 'background_color'
+        self.element.background_color(5, 10, 15, 100)
+        self.child_element_test(tag_name, 'color', None, {'red': '5', 'green': '10', 'blue': '15', 'alpha': '100'})
+
+    def test_background_color_hex(self):
+        tag_name = 'background_color'
+        self.element.background_color('#ffffc3')
+        self.child_element_test(tag_name, 'color', None, {'red': '255', 'green': '255',
+                                                          'blue': '195', 'alpha': '255'})
+
+    def test_background_color_hex_alpha(self):
+        tag_name = 'background_color'
+        self.element.background_color('#ffffc3', 100)
+        self.child_element_test(tag_name, 'color', None, {'red': '255', 'green': '255',
+                                                          'blue': '195', 'alpha': '100'})
+        
+    def test_background_color_bad_args(self):
+        tag_name = 'background_color'
+        self.assertRaises(TypeError, self.element.background_color, 5, 10, 15, '#ffffff')
 
 
 class TestTransparent(GenericTest):


### PR DESCRIPTION
Added hex value option to foreground color and background color methods.

Changed parameter to accept either 3 rgb values or 1 hex value.

Added new test cases and successfully ran tests locally.

Python doesn't have a great way to have different number of parameters for a single function. [Followed stack overflow thread](https://stackoverflow.com/questions/5079609/methods-with-the-same-name-in-one-class-in-python/74745600#74745600)